### PR TITLE
adding --body-regex option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Available individual target settings:
 - Timeout (default 10s)
 - Method (default GET)
 - Body (default empty)
+- RegexBody (default false)
 - BodyFilename (default none)
 - Headers (default none)
 - Cookies (default none)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,7 @@ func init() {
 	RootCmd.PersistentFlags().StringP("timeout", "t", "10s", "Maximum seconds to wait for response")
 	RootCmd.PersistentFlags().StringP("request-method", "X", "GET", "Request type. GET, HEAD, POST, PUT, etc.")
 	RootCmd.PersistentFlags().String("body", "", "String to use as request body e.g. POST body.")
+	RootCmd.PersistentFlags().BoolP("body-regex", "", false, "Interpret Body as regular expressions.")
 	RootCmd.PersistentFlags().String("body-file", "", "Path to file to use as request body. Will overwrite --body if both are present.")
 	RootCmd.PersistentFlags().StringP("headers", "H", "", "Add arbitrary header line, eg. 'Accept-Encoding:gzip, Content-Type:application/json'")
 	RootCmd.PersistentFlags().String("cookies", "", "Add request cookies, eg. 'data=123; session=456'")

--- a/cmd/stress.go
+++ b/cmd/stress.go
@@ -52,6 +52,7 @@ var stressCmd = &cobra.Command{
 				stressCfg.Targets[i].Timeout = viper.GetString("timeout")
 				stressCfg.Targets[i].Method = viper.GetString("request-method")
 				stressCfg.Targets[i].Body = viper.GetString("body")
+				stressCfg.Targets[i].RegexBody = viper.GetBool("body-regex")
 				stressCfg.Targets[i].BodyFilename = viper.GetString("body-file")
 				stressCfg.Targets[i].Headers = viper.GetString("headers")
 				stressCfg.Targets[i].Cookies = viper.GetString("cookies")
@@ -84,6 +85,9 @@ var stressCmd = &cobra.Command{
 				}
 				if _, set := targetMapVals["Body"]; !set {
 					stressCfg.Targets[i].Body = viper.GetString("body")
+				}
+				if _, set := targetMapVals["RegexBody"]; !set {
+					stressCfg.Targets[i].RegexBody = viper.GetBool("body-regex")
 				}
 				if _, set := targetMapVals["BodyFilename"]; !set {
 					stressCfg.Targets[i].BodyFilename = viper.GetString("bodyFile")

--- a/lib/target.go
+++ b/lib/target.go
@@ -30,6 +30,9 @@ type (
 		Method string
 		//String that is the content of the HTTP body. Empty string is no body.
 		Body string
+		// Whether or not to interpret the Body as regular expression string
+		// and generate actual body from that
+		RegexBody bool
 		//A location on disk to read the HTTP body from. Empty string means it will not be read.
 		BodyFilename    string
 		Headers         string

--- a/lib/util.go
+++ b/lib/util.go
@@ -93,7 +93,15 @@ func buildRequest(t Target) (http.Request, error) {
 		}
 		req, err = http.NewRequest(t.Method, URL.String(), bytes.NewBuffer(fileContents))
 	} else if t.Body != "" {
-		req, err = http.NewRequest(t.Method, URL.String(), bytes.NewBuffer([]byte(t.Body)))
+		// req, err = http.NewRequest(t.Method, URL.String(), bytes.NewBuffer([]byte(t.Body)))
+		bodyStr := t.Body
+		if t.RegexBody {
+			bodyStr, err = reggen.Generate(t.Body, 10)
+			if err != nil {
+				return http.Request{}, errors.New("failed to parse regex: " + err.Error())
+			}
+		}
+		req, err = http.NewRequest(t.Method, URL.String(), bytes.NewBuffer([]byte(bodyStr)))
 	} else {
 		req, err = http.NewRequest(t.Method, URL.String(), nil)
 	}

--- a/lib/util.go
+++ b/lib/util.go
@@ -93,7 +93,6 @@ func buildRequest(t Target) (http.Request, error) {
 		}
 		req, err = http.NewRequest(t.Method, URL.String(), bytes.NewBuffer(fileContents))
 	} else if t.Body != "" {
-		// req, err = http.NewRequest(t.Method, URL.String(), bytes.NewBuffer([]byte(t.Body)))
 		bodyStr := t.Body
 		if t.RegexBody {
 			bodyStr, err = reggen.Generate(t.Body, 10)


### PR DESCRIPTION
Before you submit a pull request, please make sure you have read and followed the contributing guidelines

### Description
i added a new option `--body-regex`. this allows to generate different values (following the regex) at every request.
my use-case where i needed that option, was when i wanted to make 10k user signup requests, where each request would have a unique username.

`pewpew  stress -X POST --body-regex --body '{"username":"test_[a-z]{3,10}@(me|you)\.(org|net)","password":"secret123"}' -H "Content-Type:application/json" https://httpbin.org/post`

### Does this close any currently open issues?
No.
