### PR TITLE
tests: general cleanup

### DIFF
--- a/lib/benchmark_test.go
+++ b/lib/benchmark_test.go
@@ -7,125 +7,236 @@ import (
 )
 
 func TestRunBenchmark(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
+		name            string
 		benchmarkConfig BenchmarkConfig
 		writer          io.Writer
-		hasErr          bool
+		expectErr       bool
 	}{
-		{BenchmarkConfig{}, ioutil.Discard, true},                      //invalid config
-		{BenchmarkConfig{}, nil, true},                                 //empty writer
-		{BenchmarkConfig{Targets: []Target{{}}}, ioutil.Discard, true}, //invalid target
-		{BenchmarkConfig{RPS: 10, Duration: 1, Targets: []Target{{URL: "*(", RegexURL: true, Method: "GET"}}}, ioutil.Discard, true}, //error building target, invalid regex
-		{BenchmarkConfig{RPS: 10, Duration: 1, Targets: []Target{{URL: ":::fail", Method: "GET"}}}, ioutil.Discard, true},            //error building target, invalid url
-
-		//good cases
-		{BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}, {URL: "http://localhost", Method: "GET"}}}, ioutil.Discard, false}, //multiple targets
-		{BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}}, ioutil.Discard, false},                                           //single target
-		{BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost:999999999", Method: "GET"}}}, ioutil.Discard, false},                                 //request that should cause an http err that will get handled
-		{BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, NoHTTP2: true}, ioutil.Discard, false},                            //noHTTP
-		{BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Timeout: "2s"}, ioutil.Discard, false},                            //timeout
-		{BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, FollowRedirects: true}, ioutil.Discard, false},                    //follow redirects
-		{BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, FollowRedirects: false}, ioutil.Discard, false},                   //don't follow redirects
-		{BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Verbose: true}, ioutil.Discard, false},                            //verbose
-		{BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Quiet: true}, ioutil.Discard, false},                              //quiet
-		{BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, BodyFilename: tempFilename}, ioutil.Discard, false},               //body file
-		{*NewBenchmarkConfig(), ioutil.Discard, false},
+		{
+			name:            "empty config",
+			benchmarkConfig: BenchmarkConfig{},
+			writer:          ioutil.Discard,
+			expectErr:       true,
+		},
+		{
+			name:            "empty writer",
+			benchmarkConfig: BenchmarkConfig{},
+			writer:          nil,
+			expectErr:       true,
+		},
+		{
+			name:            "empty target",
+			benchmarkConfig: BenchmarkConfig{Targets: []Target{{}}},
+			writer:          ioutil.Discard,
+			expectErr:       true,
+		},
+		{
+			name:            "invalid regex",
+			benchmarkConfig: BenchmarkConfig{RPS: 10, Duration: 1, Targets: []Target{{URL: "*(", RegexURL: true, Method: "GET"}}},
+			writer:          ioutil.Discard,
+			expectErr:       true,
+		},
+		{
+			name:            "invalid url",
+			benchmarkConfig: BenchmarkConfig{RPS: 10, Duration: 1, Targets: []Target{{URL: ":::fail", Method: "GET"}}},
+			writer:          ioutil.Discard,
+			expectErr:       true,
+		},
+		{
+			name:            "multiple targets",
+			benchmarkConfig: BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}, {URL: "http://localhost", Method: "GET"}}},
+			writer:          ioutil.Discard,
+			expectErr:       false,
+		},
+		{
+			name:            "single target",
+			benchmarkConfig: BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}},
+			writer:          ioutil.Discard,
+			expectErr:       false,
+		},
+		{
+			name:            "expected http error",
+			benchmarkConfig: BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost:999999999", Method: "GET"}}},
+			writer:          ioutil.Discard,
+			expectErr:       false,
+		},
+		{
+			name:            "No HTTP2",
+			benchmarkConfig: BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, NoHTTP2: true},
+			writer:          ioutil.Discard,
+			expectErr:       false,
+		},
+		{
+			name:            "timeout",
+			benchmarkConfig: BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Timeout: "2s"},
+			writer:          ioutil.Discard,
+			expectErr:       false,
+		},
+		{
+			name:            "follow redirects",
+			benchmarkConfig: BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, FollowRedirects: true},
+			writer:          ioutil.Discard,
+			expectErr:       false,
+		},
+		{
+			name:            "don't follow redirects",
+			benchmarkConfig: BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, FollowRedirects: false},
+			writer:          ioutil.Discard,
+			expectErr:       false,
+		},
+		{
+			name:            "verbose",
+			benchmarkConfig: BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Verbose: true},
+			writer:          ioutil.Discard,
+			expectErr:       false,
+		},
+		{
+			name:            "quiet",
+			benchmarkConfig: BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Quiet: true},
+			writer:          ioutil.Discard,
+			expectErr:       false,
+		},
+		{
+			name:            "body file",
+			benchmarkConfig: BenchmarkConfig{RPS: 1, Duration: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, BodyFilename: tempFilename},
+			writer:          ioutil.Discard,
+			expectErr:       false,
+		},
+		{
+			name:            "BenchmarkConfig constructor",
+			benchmarkConfig: *NewBenchmarkConfig(),
+			writer:          ioutil.Discard,
+			expectErr:       false,
+		},
 	}
-	for _, c := range cases {
-		_, err := RunBenchmark(c.benchmarkConfig, c.writer)
-		if (err != nil) != c.hasErr {
-			t.Errorf("RunBenchmark(%+v, %q) err: %t wanted %t", c.benchmarkConfig, c.writer, (err != nil), c.hasErr)
-		}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := RunBenchmark(tc.benchmarkConfig, tc.writer)
+			if (err != nil) != tc.expectErr {
+				t.Errorf("got error: %t, wanted: %t", (err != nil), tc.expectErr)
+			}
+		})
 	}
 }
 
 func TestValidateBenchmarkConfig(t *testing.T) {
-	cases := []struct {
-		s      BenchmarkConfig
-		hasErr bool
+	tests := []struct {
+		name      string
+		config    BenchmarkConfig
+		expectErr bool
 	}{
-		//multiple things uninitialized
-		{BenchmarkConfig{}, true},
-		//zero rps
-		{BenchmarkConfig{
-			RPS:      0,
-			Duration: DefaultDuration,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: DefaultTimeout,
-					Method:  DefaultMethod,
+		{
+			name:      "uninitialized",
+			config:    BenchmarkConfig{},
+			expectErr: true,
+		},
+		{
+			name: "zero rps",
+			config: BenchmarkConfig{
+				RPS:      0,
+				Duration: DefaultDuration,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: DefaultTimeout,
+						Method:  DefaultMethod,
+					},
 				},
 			},
-		}, true},
-		//zero duration
-		{BenchmarkConfig{
-			RPS:      DefaultRPS,
-			Duration: 0,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: DefaultTimeout,
-					Method:  DefaultMethod,
+			expectErr: true,
+		},
+		{
+			name: "zero duration",
+			config: BenchmarkConfig{
+				RPS:      DefaultRPS,
+				Duration: 0,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: DefaultTimeout,
+						Method:  DefaultMethod,
+					},
 				},
 			},
-		}, true},
-		//empty method
-		{BenchmarkConfig{
-			RPS:      DefaultRPS,
-			Duration: DefaultDuration,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: DefaultTimeout,
-					Method:  "",
+			expectErr: true,
+		},
+		{
+			name: "empty method",
+			config: BenchmarkConfig{
+				RPS:      DefaultRPS,
+				Duration: DefaultDuration,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: DefaultTimeout,
+						Method:  "",
+					},
 				},
 			},
-		}, true},
-		//empty timeout string okay
-		{BenchmarkConfig{
-			RPS:      DefaultRPS,
-			Duration: DefaultDuration,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: "",
-					Method:  DefaultMethod,
+			expectErr: true,
+		},
+		{
+			name: "empty timeout",
+			config: BenchmarkConfig{
+				RPS:      DefaultRPS,
+				Duration: DefaultDuration,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: "",
+						Method:  DefaultMethod,
+					},
 				},
 			},
-		}, false},
-		//invalid time string
-		{BenchmarkConfig{
-			RPS:      DefaultRPS,
-			Duration: DefaultDuration,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: "unparseable",
-					Method:  DefaultMethod,
+			expectErr: false,
+		},
+		{
+			name: "unparseable time string",
+			config: BenchmarkConfig{
+				RPS:      DefaultRPS,
+				Duration: DefaultDuration,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: "unparseable",
+						Method:  DefaultMethod,
+					},
 				},
 			},
-		}, true},
-		//timeout too short
-		{BenchmarkConfig{
-			RPS:      DefaultRPS,
-			Duration: DefaultDuration,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: "1ms",
-					Method:  DefaultMethod,
+			expectErr: true,
+		},
+		{
+			name: "timeout too short",
+			config: BenchmarkConfig{
+				RPS:      DefaultRPS,
+				Duration: DefaultDuration,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: "1ms",
+						Method:  DefaultMethod,
+					},
 				},
 			},
-		}, true},
-
-		//good cases
-		{*NewBenchmarkConfig(), false},
+			expectErr: true,
+		},
+		{
+			name:      "valid",
+			config:    *NewBenchmarkConfig(),
+			expectErr: false,
+		},
 	}
-	for _, c := range cases {
-		err := validateBenchmarkConfig(c.s)
-		if (err != nil) != c.hasErr {
-			t.Errorf("validateBenchmarkConfig(%+v) err: %t wanted %t", c.s, (err != nil), c.hasErr)
-		}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateBenchmarkConfig(tc.config)
+			if (err != nil) != tc.expectErr {
+				t.Errorf("got error: %t, wanted: %t", (err != nil), tc.expectErr)
+			}
+		})
 	}
 }

--- a/lib/printer_test.go
+++ b/lib/printer_test.go
@@ -9,62 +9,118 @@ import (
 )
 
 func TestCreateTextSummary(t *testing.T) {
-	cases := []struct {
-		s RequestStatSummary
+	tests := []struct {
+		name string
+		s    RequestStatSummary
 	}{
-		{RequestStatSummary{}}, //empty
-		{RequestStatSummary{
-			avgRPS:               12.34,
-			avgDuration:          1234,
-			minDuration:          1234,
-			maxDuration:          1234,
-			statusCodes:          map[int]int{100: 1, 200: 2, 300: 3, 400: 4, 500: 5, 0: 1},
-			startTime:            time.Now(),
-			endTime:              time.Now(),
-			avgDataTransferred:   2345,
-			maxDataTransferred:   12345,
-			minDataTransferred:   1234,
-			totalDataTransferred: 123456,
-		}}, //nonzero values for everything
+		{
+			name: "empty summary",
+			s:    RequestStatSummary{},
+		},
+		{
+			name: "valid summary, non-zero values",
+			s: RequestStatSummary{
+				avgRPS:               12.34,
+				avgDuration:          1234,
+				minDuration:          1234,
+				maxDuration:          1234,
+				statusCodes:          map[int]int{100: 1, 200: 2, 300: 3, 400: 4, 500: 5, 0: 1},
+				startTime:            time.Now(),
+				endTime:              time.Now(),
+				avgDataTransferred:   2345,
+				maxDataTransferred:   12345,
+				minDataTransferred:   1234,
+				totalDataTransferred: 123456,
+			},
+		},
 	}
-	for _, c := range cases {
-		//could check for the exact string, but that's super tedious and brittle
-		_ = CreateTextSummary(c.s)
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_ = CreateTextSummary(tc.s)
+		})
 	}
 }
 
 func TestPrintStat(t *testing.T) {
-	cases := []struct {
-		r RequestStat
+	tests := []struct {
+		name string
+		r    RequestStat
 	}{
-		{RequestStat{}}, //empty
-		//status codes
-		{RequestStat{StatusCode: 100}},
-		{RequestStat{StatusCode: 200}},
-		{RequestStat{StatusCode: 300}},
-		{RequestStat{StatusCode: 400}},
-		{RequestStat{StatusCode: 500}},
-		//error case
-		{RequestStat{Error: errors.New("this is an error")}},
+		{
+			name: "empty stat",
+			r:    RequestStat{},
+		},
+		{
+			name: "status code 100",
+			r:    RequestStat{StatusCode: 100},
+		},
+		{
+			name: "status code 200",
+			r:    RequestStat{StatusCode: 200},
+		},
+		{
+			name: "status code 300",
+			r:    RequestStat{StatusCode: 300},
+		},
+		{
+			name: "status code 400",
+			r:    RequestStat{StatusCode: 400},
+		},
+		{
+			name: "status code 500",
+			r:    RequestStat{StatusCode: 500},
+		},
+		{
+			name: "error",
+			r:    RequestStat{Error: errors.New("this is an error")},
+		},
 	}
-	p := printer{output: ioutil.Discard}
-	for _, c := range cases {
-		p.printStat(c.r)
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := printer{output: ioutil.Discard}
+			p.printStat(tc.r)
+
+		})
 	}
 }
 
 func TestPrintVerbose(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
+		name string
 		req  *http.Request
 		resp *http.Response
 	}{
-		{nil, nil},
-		{nil, &http.Response{}},
-		{&http.Request{}, nil},
-		{&http.Request{}, &http.Response{Body: http.NoBody}},
+		{
+			name: "nil request and response",
+			req:  nil,
+			resp: nil,
+		},
+		{
+			name: "nil request and empty response",
+			req:  nil,
+			resp: &http.Response{},
+		},
+		{
+			name: "empty request and nil response",
+			req:  &http.Request{},
+			resp: nil,
+		},
+		{
+			name: "non-empty request and response",
+			req:  &http.Request{},
+			resp: &http.Response{Body: http.NoBody},
+		},
 	}
-	p := printer{output: ioutil.Discard}
-	for _, c := range cases {
-		p.printVerbose(c.req, c.resp)
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := printer{output: ioutil.Discard}
+			p.printVerbose(tc.req, tc.resp)
+		})
 	}
 }

--- a/lib/requester_test.go
+++ b/lib/requester_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRunRequest(t *testing.T) {
-	badRequest, err := http.NewRequest("GET", "http://1234567890.0987654321", nil)
+	invalidURLRequest, err := http.NewRequest("GET", "http://1234567890.0987654321", nil)
 	if err != nil {
 		t.Errorf("failed to create bad http request")
 	}
@@ -15,14 +15,28 @@ func TestRunRequest(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create good http request with no body")
 	}
-	cases := []struct {
-		r http.Request
-		c *http.Client
+
+	tests := []struct {
+		name string
+		r    http.Request
+		c    *http.Client
 	}{
-		{*badRequest, &http.Client{}},
-		{*goodRequestWithNoBody, &http.Client{}},
+		{
+			name: "invalid url",
+			r:    *invalidURLRequest,
+			c:    &http.Client{},
+		},
+		{
+			name: "valid",
+			r:    *goodRequestWithNoBody,
+			c:    &http.Client{},
+		},
 	}
-	for _, c := range cases {
-		runRequest(c.r, c.c)
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runRequest(tc.r, tc.c)
+		})
 	}
 }

--- a/lib/stress_test.go
+++ b/lib/stress_test.go
@@ -29,137 +29,251 @@ func TestMain(m *testing.M) {
 }
 
 func TestRunStress(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
+		name         string
 		stressConfig StressConfig
 		writer       io.Writer
-		hasErr       bool
+		expectErr    bool
 	}{
-		{StressConfig{}, ioutil.Discard, true},                      //invalid config
-		{StressConfig{}, nil, true},                                 //empty writer
-		{StressConfig{Targets: []Target{{}}}, ioutil.Discard, true}, //invalid target
-		{StressConfig{Count: 10, Concurrency: 1, Targets: []Target{{URL: "*(", RegexURL: true, Method: "GET"}}}, ioutil.Discard, true}, //error building target, invalid regex
-		{StressConfig{Count: 10, Concurrency: 1, Targets: []Target{{URL: ":::fail", Method: "GET"}}}, ioutil.Discard, true},            //error building target, invalid url
-
-		//good cases
-		{StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}, {URL: "http://localhost", Method: "GET"}}}, ioutil.Discard, false}, //multiple targets
-		{StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}}, ioutil.Discard, false},                                           //single target
-		{StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost:999999999", Method: "GET"}}}, ioutil.Discard, false},                                 //request that should cause an http err that will get handled
-		{StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, NoHTTP2: true}, ioutil.Discard, false},                            //noHTTP
-		{StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Timeout: "2s"}, ioutil.Discard, false},                            //timeout
-		{StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, FollowRedirects: true}, ioutil.Discard, false},                    //follow redirects
-		{StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, FollowRedirects: false}, ioutil.Discard, false},                   //don't follow redirects
-		{StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Verbose: true}, ioutil.Discard, false},                            //verbose
-		{StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Quiet: true}, ioutil.Discard, false},                              //quiet
-		{StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, BodyFilename: tempFilename}, ioutil.Discard, false},               //body file
-		{*NewStressConfig(), ioutil.Discard, false},
+		{
+			name:         "empty config",
+			stressConfig: StressConfig{},
+			writer:       ioutil.Discard,
+			expectErr:    true,
+		},
+		{
+			name:         "empty writer",
+			stressConfig: StressConfig{},
+			writer:       nil,
+			expectErr:    true,
+		},
+		{
+			name:         "invalid target",
+			stressConfig: StressConfig{Targets: []Target{{}}},
+			writer:       ioutil.Discard,
+			expectErr:    true,
+		},
+		{
+			name:         "invalid regex",
+			stressConfig: StressConfig{Count: 10, Concurrency: 1, Targets: []Target{{URL: "*(", RegexURL: true, Method: "GET"}}},
+			writer:       ioutil.Discard,
+			expectErr:    true,
+		},
+		{
+			name:         "invalid url",
+			stressConfig: StressConfig{Count: 10, Concurrency: 1, Targets: []Target{{URL: ":::fail", Method: "GET"}}},
+			writer:       ioutil.Discard,
+			expectErr:    true,
+		},
+		{
+			name:         "valid single targets",
+			stressConfig: StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}},
+			writer:       ioutil.Discard,
+			expectErr:    false,
+		},
+		{
+			name:         "valid multiple targets",
+			stressConfig: StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}, {URL: "http://localhost", Method: "GET"}}},
+			writer:       ioutil.Discard,
+			expectErr:    false,
+		},
+		{
+			name:         "valid config, handleable http error",
+			stressConfig: StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost:999999999", Method: "GET"}}},
+			writer:       ioutil.Discard,
+			expectErr:    false,
+		},
+		{
+			name:         "valid no HTTP2",
+			stressConfig: StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, NoHTTP2: true},
+			writer:       ioutil.Discard,
+			expectErr:    false,
+		},
+		{
+			name:         "valid timeout",
+			stressConfig: StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Timeout: "2s"},
+			writer:       ioutil.Discard,
+			expectErr:    false,
+		},
+		{
+			name:         "valid following redirects",
+			stressConfig: StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, FollowRedirects: true},
+			writer:       ioutil.Discard,
+			expectErr:    false,
+		},
+		{
+			name:         "valid not following redirects",
+			stressConfig: StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, FollowRedirects: false},
+			writer:       ioutil.Discard,
+			expectErr:    false,
+		},
+		{
+			name:         "valid verbose",
+			stressConfig: StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Verbose: true},
+			writer:       ioutil.Discard,
+			expectErr:    false,
+		},
+		{
+			name:         "valid quiet",
+			stressConfig: StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, Quiet: true},
+			writer:       ioutil.Discard,
+			expectErr:    false,
+		},
+		{
+			name:         "valid body file",
+			stressConfig: StressConfig{Count: 1, Concurrency: 1, Targets: []Target{{URL: "http://localhost", Method: "GET"}}, BodyFilename: tempFilename},
+			writer:       ioutil.Discard,
+			expectErr:    false,
+		},
+		{
+			name:         "valid stressConfig constructor",
+			stressConfig: *NewStressConfig(),
+			writer:       ioutil.Discard,
+			expectErr:    false,
+		},
 	}
-	for _, c := range cases {
-		_, err := RunStress(c.stressConfig, c.writer)
-		if (err != nil) != c.hasErr {
-			t.Errorf("RunStress(%+v, %q) err: %t wanted %t", c.stressConfig, c.writer, (err != nil), c.hasErr)
-		}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := RunStress(tc.stressConfig, tc.writer)
+			if (err != nil) != tc.expectErr {
+				t.Errorf("got error: %t, wanted: %t", (err != nil), tc.expectErr)
+			}
+		})
 	}
 }
 
 func TestValidateStressConfig(t *testing.T) {
-	cases := []struct {
-		s      StressConfig
-		hasErr bool
+	tests := []struct {
+		name      string
+		s         StressConfig
+		expectErr bool
 	}{
-		//multiple things uninitialized
-		{StressConfig{}, true},
-		//zero count
-		{StressConfig{
-			Count:       0,
-			Concurrency: DefaultConcurrency,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: DefaultTimeout,
-					Method:  DefaultMethod,
+		{
+			name:      "uninitialized",
+			s:         StressConfig{},
+			expectErr: true,
+		},
+		{
+			name: "count is zero",
+			s: StressConfig{
+				Count:       0,
+				Concurrency: DefaultConcurrency,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: DefaultTimeout,
+						Method:  DefaultMethod,
+					},
 				},
 			},
-		}, true},
-		//zero concurrency
-		{StressConfig{
-			Count:       DefaultCount,
-			Concurrency: 0,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: DefaultTimeout,
-					Method:  DefaultMethod,
+			expectErr: true,
+		},
+		{
+			name: "concurrency is zero",
+			s: StressConfig{
+				Count:       DefaultCount,
+				Concurrency: 0,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: DefaultTimeout,
+						Method:  DefaultMethod,
+					},
 				},
 			},
-		}, true},
-		//concurrency > count
-		{StressConfig{
-			Count:       10,
-			Concurrency: 20,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: DefaultTimeout,
-					Method:  DefaultMethod,
+			expectErr: true,
+		},
+		{
+			name: "concurrency > count",
+			s: StressConfig{
+				Count:       10,
+				Concurrency: 20,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: DefaultTimeout,
+						Method:  DefaultMethod,
+					},
 				},
 			},
-		}, true},
-		//empty method
-		{StressConfig{
-			Count:       DefaultCount,
-			Concurrency: DefaultConcurrency,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: DefaultTimeout,
-					Method:  "",
+			expectErr: true,
+		},
+		{
+			name: "empty method",
+			s: StressConfig{
+				Count:       DefaultCount,
+				Concurrency: DefaultConcurrency,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: DefaultTimeout,
+						Method:  "",
+					},
 				},
 			},
-		}, true},
-		//empty timeout string okay
-		{StressConfig{
-			Count:       DefaultCount,
-			Concurrency: DefaultConcurrency,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: "",
-					Method:  DefaultMethod,
+			expectErr: true,
+		},
+		{
+			name: "valid empty timeout string",
+			s: StressConfig{
+				Count:       DefaultCount,
+				Concurrency: DefaultConcurrency,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: "",
+						Method:  DefaultMethod,
+					},
 				},
 			},
-		}, false},
-		//invalid time string
-		{StressConfig{
-			Count:       DefaultCount,
-			Concurrency: DefaultConcurrency,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: "unparseable",
-					Method:  DefaultMethod,
+			expectErr: false,
+		},
+		{
+			name: "invalid time string",
+			s: StressConfig{
+				Count:       DefaultCount,
+				Concurrency: DefaultConcurrency,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: "unparseable",
+						Method:  DefaultMethod,
+					},
 				},
 			},
-		}, true},
-		//timeout too short
-		{StressConfig{
-			Count:       DefaultCount,
-			Concurrency: DefaultConcurrency,
-			Targets: []Target{
-				{
-					URL:     DefaultURL,
-					Timeout: "1ms",
-					Method:  DefaultMethod,
+			expectErr: true,
+		},
+		{
+			name: "timeout too short",
+			s: StressConfig{
+				Count:       DefaultCount,
+				Concurrency: DefaultConcurrency,
+				Targets: []Target{
+					{
+						URL:     DefaultURL,
+						Timeout: "1ms",
+						Method:  DefaultMethod,
+					},
 				},
 			},
-		}, true},
-
-		//good cases
-		{*NewStressConfig(), false},
+			expectErr: true,
+		},
+		{
+			name:      "valid",
+			s:         *NewStressConfig(),
+			expectErr: false,
+		},
 	}
-	for _, c := range cases {
-		err := validateStressConfig(c.s)
-		if (err != nil) != c.hasErr {
-			t.Errorf("validateStressConfig(%+v) err: %t wanted %t", c.s, (err != nil), c.hasErr)
-		}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateStressConfig(tc.s)
+			if (err != nil) != tc.expectErr {
+				t.Errorf("got error: %t, wanted: %t", (err != nil), tc.expectErr)
+			}
+		})
 	}
 }

--- a/lib/target_test.go
+++ b/lib/target_test.go
@@ -5,41 +5,61 @@ import (
 )
 
 func TestValidateTarget(t *testing.T) {
-	cases := []struct {
-		t      Target
-		hasErr bool
+	tests := []struct {
+		name      string
+		t         Target
+		expectErr bool
 	}{
-		//multiple things uninitialized
-		{Target{}, true},
-		//empty method
-		{Target{
-			URL:     DefaultURL,
-			Timeout: DefaultTimeout,
-			Method:  "",
-		}, true},
-		//empty timeout string okay
-		{Target{
-			URL:     DefaultURL,
-			Timeout: "",
-			Method:  DefaultMethod,
-		}, false},
-		//invalid time string
-		{Target{
-			URL:     DefaultURL,
-			Timeout: "unparseable",
-			Method:  DefaultMethod,
-		}, true},
-		//timeout too short
-		{Target{
-			URL:     DefaultURL,
-			Timeout: "1ms",
-			Method:  DefaultMethod,
-		}, true},
+		{
+			name:      "uninitialized target",
+			t:         Target{},
+			expectErr: true,
+		},
+		{
+			name: "empty method",
+			t: Target{
+				URL:     DefaultURL,
+				Timeout: DefaultTimeout,
+				Method:  "",
+			},
+			expectErr: true,
+		},
+		{
+			name: "valid empty timeout",
+			t: Target{
+				URL:     DefaultURL,
+				Timeout: "",
+				Method:  DefaultMethod,
+			},
+			expectErr: false,
+		},
+		{
+			name: "unparseable string",
+			t: Target{
+				URL:     DefaultURL,
+				Timeout: "unparseable",
+				Method:  DefaultMethod,
+			},
+			expectErr: true,
+		},
+		{
+			name: "timeout too short",
+			t: Target{
+				URL:     DefaultURL,
+				Timeout: "1ms",
+				Method:  DefaultMethod,
+			},
+			expectErr: true,
+		},
 	}
-	for _, c := range cases {
-		err := validateTarget(c.t)
-		if (err != nil) != c.hasErr {
-			t.Errorf("validateTarget(%+v) err: %t wanted %t", c.t, (err != nil), c.hasErr)
-		}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateTarget(tc.t)
+			if (err != nil) != tc.expectErr {
+				t.Errorf("got error: %t, wanted: %t", (err != nil), tc.expectErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
* use standard go naming conventions
* name individual test cases
* parallelize tests