### PR TITLE
feat: support providing target urls as pipe or file path

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -36,6 +36,12 @@ var benchmarkCmd = &cobra.Command{
 		//URLs are handled differently that other config options
 		//command line specifying URLs take higher precedence than config URLs
 
+		extraURLs, err := readURLs()
+		if err != nil {
+			return err
+		}
+		args = append(args, extraURLs...)
+
 		//check either set via config or command line
 		if len(benchmarkCfg.Targets) == 0 && len(args) < 1 {
 			return errors.New("requires URL")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,7 @@ func init() {
 	RootCmd.PersistentFlags().String("output-xml", "", "Path to file to write full data as XML")
 	RootCmd.PersistentFlags().BoolP("quiet", "q", false, "Do not print while requests are running.")
 	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "Print extra troubleshooting info.")
+	RootCmd.PersistentFlags().StringP("targets-file", "f", "", "Path to file with newline-separated target URLs.")
 	RootCmd.PersistentFlags().Int("cpu", runtime.GOMAXPROCS(0), "Number of CPUs to use.")
 
 	err = viper.BindPFlags(RootCmd.PersistentFlags())

--- a/cmd/stress.go
+++ b/cmd/stress.go
@@ -35,6 +35,12 @@ var stressCmd = &cobra.Command{
 		//URLs are handled differently that other config options
 		//command line specifying URLs take higher precedence than config URLs
 
+		extraURLs, err := readURLs()
+		if err != nil {
+			return err
+		}
+		args = append(args, extraURLs...)
+
 		//check either set via config or command line
 		if len(stressCfg.Targets) == 0 && len(args) < 1 {
 			return errors.New("requires URL")

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// Read target URLs from stdin (if piped) or a --targets-file
+func readURLs() ([]string, error) {
+	targetsFile := viper.GetString("targets-file")
+
+	stdinInfo, err := os.Stdin.Stat()
+	if err != nil {
+		return nil, err
+	}
+	stdinPiped := (stdinInfo.Mode() & os.ModeCharDevice) == 0
+
+	if stdinPiped && targetsFile != "" {
+		return nil, errors.New("cannot use both piped stdin and --targets-file")
+	}
+
+	if stdinPiped {
+		return scanURLs(os.Stdin)
+	}
+
+	if targetsFile != "" {
+		f, err := os.Open(targetsFile)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		return scanURLs(f)
+	}
+
+	return nil, nil
+}
+
+// Reads lines from r, skipping empty lines and comments (lines starting with #)
+func scanURLs(r io.Reader) ([]string, error) {
+	var urls []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		urls = append(urls, line)
+	}
+	return urls, scanner.Err()
+}


### PR DESCRIPTION
### Description

- add support for reading newline-separated URLs from stdin or a new `--targets-file` arg 
- minor fix to use correct default value for benchmark duration (noticed while I was in there)

